### PR TITLE
Change zip command, make token area explicit

### DIFF
--- a/coursera_ml/AssignmentML1.ipynb
+++ b/coursera_ml/AssignmentML1.ipynb
@@ -154,14 +154,24 @@
     }
    ],
    "source": [
-    "!zip -r a2_m1.json.zip a2_m1.json"
+    "import shutil\n\n",
+    "shutil.make_archive(\"a2_m1.json\", \"zip\", base_dir=\"a2_m1.json\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+      "outputs": [
+      {
+       "output_type": "execute_result",
+       "data": {
+        "text/plain": "'a2_m1.json.zip'"
+       },
+       "execution_count": 30,
+       "metadata": {}
+      }
+     ],
    "source": [
     "!base64 a2_m1.json.zip > a2_m1.json.zip.base64"
    ]
@@ -183,8 +193,8 @@
     "from rklib import submit\n",
     "key = \"1injH2F0EeiLlRJ3eJKoXA\"\n",
     "part = \"wNLDt\"\n",
-    "email = \"romeo.kienzler@ch.ibm.com\"\n",
-    "secret = \"LmH3xl5RfXEcpMMb\"\n",
+    "email = \"##EMAIL ADDRESS HERE##\"\n",
+    "secret = \"##TOKEN HERE##\"\n",
     "\n",
     "with open('a2_m1.json.zip.base64', 'r') as myfile:\n",
     "    data=myfile.read()\n",


### PR DESCRIPTION
Latest notebook environments aren't exposing zip.  This methodology was provided by Tinguaro Barreno in the forums and worked with submission.
It wasn't clear if the token went in the (likely) "secret" or (possible) "key" field.  This should make it more explicit.