### PR TITLE
Define "features_norm" as featuresCol

### DIFF
--- a/coursera_ml/a2_w1_s3_SparkML_GBT.ipynb
+++ b/coursera_ml/a2_w1_s3_SparkML_GBT.ipynb
@@ -82,7 +82,7 @@
    "source": [
     "from pyspark.ml.classification import GBTClassifier\n",
     "\n",
-    "gbt = GBTClassifier(labelCol=\"label\", featuresCol=\"features\", maxIter=10)"
+    "gbt = GBTClassifier(labelCol=\"label\", featuresCol=\"features_norm\", maxIter=10)"
    ]
   },
   {


### PR DESCRIPTION
Define the normalizes features as featuresCol in GBTClassifier. Otherwise, the pipeline's normalizer stage wouldn't be useful.